### PR TITLE
Endpoints para api de usuarios

### DIFF
--- a/app/Actions/Role/AttachRoleToUser.php
+++ b/app/Actions/Role/AttachRoleToUser.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Role;
+
+use App\Models\User;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class AttachRoleToUser
+{
+    use AsAction;
+
+    public function handle(User $user, string $role): User
+    {
+        return $user->assignRole($role);
+    }
+}

--- a/app/Actions/User/CreateUser.php
+++ b/app/Actions/User/CreateUser.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\User;
+
+use App\Actions\Role\AttachRoleToUser;
+use App\Events\UserCreated;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class CreateUser
+{
+    use AsAction;
+
+    public function __construct(private AttachRoleToUser $attachRoleToUser)
+    {
+    }
+
+    public function handle(array $fields): User
+    {
+        return DB::transaction(fn () => $this->attachRoleToUser->run($this->createUser($fields), $fields['role']));
+    }
+
+    private function createUser(array $fields): User
+    {
+        $fields['password'] = $this->generatePassword();
+        $user = User::create($fields);
+        $this->dispatchEvent($user, $fields['password']);
+
+        return $user;
+    }
+
+    private function generatePassword(): string
+    {
+        return Str::random(10);
+    }
+
+    private function dispatchEvent($user, $password): void
+    {
+        UserCreated::dispatch($user, $password);
+    }
+}

--- a/app/Actions/User/SendCredentialsEmailToUser.php
+++ b/app/Actions/User/SendCredentialsEmailToUser.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\User;
+
+use App\Mail\CredentialsUserMail;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class SendCredentialsEmailToUser
+{
+    use AsAction;
+
+    public function handle(User $user, string $password): void
+    {
+        Mail::send(new CredentialsUserMail($user, $password));
+    }
+}

--- a/app/Actions/User/UpdateUserById.php
+++ b/app/Actions/User/UpdateUserById.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\User;
+
+use App\Models\User;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class UpdateUserById
+{
+    use AsAction;
+
+    public function __construct(private GetUserById $getUserById)
+    {
+    }
+
+    public function handle(int $userId, array $fields): User
+    {
+        $user = $this->getUserById->run($userId);
+
+        return $this->updateUser($user, $fields);
+    }
+
+    private function updateUser(User $user, array $fields): User
+    {
+        return tap($user)->update($fields);
+    }
+}

--- a/app/Events/UserCreated.php
+++ b/app/Events/UserCreated.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\User;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class UserCreated
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(public User $user, public string $password)
+    {
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Actions\User\CreateUser;
 use App\Actions\User\DeleteUserById;
-use App\Actions\User\GetUserById;
 use App\Actions\User\GetAllUsers;
+use App\Actions\User\GetUserById;
+use App\Actions\User\UpdateUserById;
+use App\Http\Requests\CreateUserRequest;
+use App\Http\Requests\UpdateUserRequest;
 use App\Http\Resources\UserResource;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
@@ -34,6 +38,28 @@ class UserController extends Controller
             $deleteUserById->run($userId);
 
             return response()->json([], 204);
+        } catch (ModelNotFoundException) {
+            return response()->json(['message' => 'User not found'], 404);
+        }
+    }
+
+    public function updateById(int $userId, UpdateUserRequest $request, UpdateUserById $updateUserById): JsonResponse
+    {
+        try {
+            $userResource = new UserResource($updateUserById->run($userId, $request->validated()));
+
+            return response()->json($userResource);
+        } catch (ModelNotFoundException) {
+            return response()->json(['message' => 'User not found'], 404);
+        }
+    }
+
+    public function create(CreateUserRequest $request, CreateUser $createUser): JsonResponse
+    {
+        try {
+            $userResource = new UserResource($createUser->run($request->validated()));
+
+            return response()->json($userResource, 201);
         } catch (ModelNotFoundException) {
             return response()->json(['message' => 'User not found'], 404);
         }

--- a/app/Http/Requests/CreateUserRequest.php
+++ b/app/Http/Requests/CreateUserRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateUserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return auth()->user()->hasPermissionTo('create-users');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'last_name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users,email',
+            'profile_img_url' => 'sometimes|string|max:255',
+            'role' => 'required|exists:roles,name'
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateUserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return auth()->user()->hasPermissionTo('edit-users');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'sometimes|string|max:255',
+            'last_name' => 'sometimes|string|max:255',
+            'profile_img_url' => 'sometimes|string|max:255',
+        ];
+    }
+}

--- a/app/Listeners/UserCreatedNotification.php
+++ b/app/Listeners/UserCreatedNotification.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Actions\User\SendCredentialsEmailToUser;
+use App\Events\UserCreated;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class UserCreatedNotification implements ShouldQueue
+{
+    public $queue = 'listeners';
+
+    public function __construct(private SendCredentialsEmailToUser $emailWithCredentialToUser)
+    {
+    }
+
+    public function handle(UserCreated $event): void
+    {
+        $this->emailWithCredentialToUser->run($event->user, $event->password);
+    }
+}

--- a/app/Mail/CredentialsUserMail.php
+++ b/app/Mail/CredentialsUserMail.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class CredentialsUserMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(protected User $user, protected string $password)
+    {
+    }
+
+    public function build(): self
+    {
+        return $this
+            ->to($this->user->email)
+            ->subject('Bienvenido a TaskApp')
+            ->view('emails.userCredentialsMail')
+            ->with([
+                'user' => $this->user,
+                'password' => $this->password,
+            ]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,17 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
 use Spatie\Permission\Traits\HasPermissions;
 use Spatie\Permission\Traits\HasRoles;
 use Tymon\JWTAuth\Contracts\JWTSubject;
 
 class User extends Authenticable implements JWTSubject
 {
-    use HasFactory, Notifiable, HasRoles, HasPermissions;
+    use HasFactory;
+    use Notifiable;
+    use HasRoles;
+    use HasPermissions;
 
     /**
      * The attributes that are mass assignable.
@@ -20,6 +27,9 @@ class User extends Authenticable implements JWTSubject
      */
     protected $fillable = [
         'name',
+        'last_name',
+        'abbreviation',
+        'profile_img_url',
         'email',
         'password',
     ];
@@ -42,6 +52,19 @@ class User extends Authenticable implements JWTSubject
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::updating(fn (User $model) => $model->abbreviation = Str::upper(Str::substr($model->name, 0, 1).Str::substr($model->last_name, 0, 1))
+        );
+
+        static::creating(function (User $model) {
+            $model->abbreviation = Str::upper(Str::substr($model->name, 0, 1).Str::substr($model->last_name, 0, 1));
+            $model->password = Hash::make($model->password);
+        });
+    }
 
     /**
      * Get the identifier that will be stored in the subject claim of the JWT.

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Providers;
 
+use App\Events\UserCreated;
+use App\Listeners\UserCreatedNotification;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -22,11 +26,9 @@ class EventServiceProvider extends ServiceProvider
 
     /**
      * Register any events for your application.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
-        //
+        Event::listen(UserCreated::class, [UserCreatedNotification::class, 'handle']);
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -24,7 +24,7 @@ class UserFactory extends Factory
             'abbreviation' => $abbreviation,
             'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'password' => 'password',
             'remember_token' => Str::random(10),
         ];
     }

--- a/resources/views/emails/userCredentialsMail.blade.php
+++ b/resources/views/emails/userCredentialsMail.blade.php
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <h1>Bienvenido a {{ config('app.name') }}</h1>
+    <p>Usuario: {{ $user->email }}</p>
+    <p>Password: {{ $password }}</p>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,6 +38,8 @@ Route::name('api.')->group(function () {
             Route::middleware('can:list-users')->get('/', [UserController::class, 'all'])->name('all');
             Route::middleware('can:list-users')->get('/{id}', [UserController::class, 'getById'])->name('getById');
             Route::middleware('can:delete-users')->delete('/{id}', [UserController::class, 'deleteById'])->name('deleteById');
+            Route::middleware('can:edit-users')->patch('/{id}', [UserController::class, 'updateById'])->name('updateById');
+            Route::middleware('can:create-users')->post('/', [UserController::class, 'create'])->name('create');
         });
     });
 });

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -4,12 +4,19 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Mail\CredentialsUserMail;
 use App\Models\User;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
 use Illuminate\Testing\Fluent\AssertableJson;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class UserTest extends TestCase
 {
+    use WithFaker;
+
     /**
      * @test
      */
@@ -139,5 +146,126 @@ class UserTest extends TestCase
         $response = $this->json('GET', route('api.users.getById', ['id' => 99]));
 
         $response->assertStatus(404);
+    }
+
+    /**
+     * @test
+     */
+    public function user_can_update_users(): void
+    {
+        $this->withoutExceptionHandling();
+        $this->actingAs(User::find(1));
+        $user = User::all()->random();
+
+        $name = $this->faker->name();
+        $lastName = $this->faker->lastName();
+        $imgUrl = $this->faker->url();
+        $abbreviation = Str::upper(Str::substr($name, 0, 1).Str::substr($lastName, 0, 1));
+
+        $response = $this->json('PATCH', route('api.users.updateById', ['id' => $user->id]), [
+            'name' => $name,
+            'last_name' => $lastName,
+            'profile_img_url' => $imgUrl,
+        ]);
+
+        $response->assertJson(fn (AssertableJson $json) => $json->where('name', $name)
+            ->where('name', $name)
+            ->where('last_name', $lastName)
+            ->where('img_profile', $imgUrl)
+            ->where('abbreviation', $abbreviation)
+            ->etc()
+        )->assertStatus(200);
+    }
+
+    /**
+     * @test
+     */
+    public function user_cannot_update_users_without_permissions(): void
+    {
+        $this->actingAs(User::find(2));
+        $user = User::all()->random();
+
+        $name = $this->faker->name();
+        $lastName = $this->faker->lastName();
+        $imgUrl = $this->faker->url();
+        $email = $this->faker->email();
+
+        $response = $this->json('PATCH', route('api.users.updateById', ['id' => $user->id]), [
+            'name' => $name,
+            'last_name' => $lastName,
+            'profile_img_url' => $imgUrl,
+            'email' => $email,
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    /**
+     * @test
+     */
+    public function user_gets_404_error_when_he_wants_update_a_user_that_does_not_exist(): void
+    {
+        $this->actingAs(User::find(1));
+        $this->withoutExceptionHandling();
+
+        $response = $this->json('PATCH', route('api.users.updateById', ['id' => 99]));
+
+        $response->assertStatus(404);
+    }
+
+    /**
+     * @test
+     */
+    public function user_can_create_users(): void
+    {
+        $this->withoutExceptionHandling();
+        $this->actingAs(User::find(1));
+
+        $name = $this->faker->name();
+        $lastName = $this->faker->lastName();
+        $imgUrl = $this->faker->url();
+        $email = $this->faker->email();
+        $role = Role::all()->random();
+        $abbreviation = Str::upper(Str::substr($name, 0, 1).Str::substr($lastName, 0, 1));
+
+        Mail::fake();
+
+        $response = $this->json('POST', route('api.users.create', [
+            'name' => $name,
+            'last_name' => $lastName,
+            'profile_img_url' => $imgUrl,
+            'email' => $email,
+            'role' => $role->name,
+        ]));
+
+        Mail::assertSent(CredentialsUserMail::class);
+
+        $response->assertJson(fn (AssertableJson $json) => $json->where('name', $name)
+            ->where('name', $name)
+            ->where('last_name', $lastName)
+            ->where('img_profile', $imgUrl)
+            ->where('abbreviation', $abbreviation)
+            ->where('email', $email)
+            ->etc()
+        )->assertStatus(201);
+    }
+
+    /**
+     * @test
+     */
+    public function user_cannot_create_users_with_incorrect_data(): void
+    {
+        $this->actingAs(User::find(1));
+
+        $response = $this->json('POST', route('api.users.create', []));
+
+        $response->assertJson(fn (AssertableJson $json) => $json->has('message')
+            ->has('errors')
+            ->whereType('errors', 'array')
+            ->whereType('message', 'string')
+            ->has('errors', fn (AssertableJson $json) => $json->hasAll(['name', 'last_name', 'email', 'role']))
+            ->where('message', 'The given data was invalid.')
+            ->etc()
+        )->assertStatus(422);
     }
 }


### PR DESCRIPTION
Añade 2  nuevos endpoints y sus correspondientes feature test:

1. Endpoint para crear usuarios.
2. Endpoint para actualizar usuarios.

*Ademas envío de email con las credenciales al usuario creado cuando se gatille el evento UserCreated
* Tambien modifica el factory de usuarios cambiando el password hasheado a sin hashear (el modelo se encargara de hashear el password).